### PR TITLE
index: use inline macro for is_empty

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -98,6 +98,7 @@ impl InMemoryIndex {
     }
 
     /// True if this index contains no data.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.word_count == 0
     }


### PR DESCRIPTION
@jimblandy small suggestion as in `Chapter 8: Crates and modules`
- "Occasionally, we need to micromanage the inline expansion of functions, an optimization that we’re usually happy to leave to the compiler. We can use the #[inline] attribute for that:"