### PR TITLE
Update to use modern Rust features

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -34,7 +34,7 @@ pub struct InMemoryIndex {
     /// document id in increasing order. This is handy for some algorithms you
     /// might want to run on the index, so we preserve this property wherever
     /// possible.
-    pub map: HashMap<String, Vec<Hit>>
+    pub map: HashMap<String, Vec<Hit>>,
 }
 
 /// A `Hit` indicates that a particular document contains some term, how many
@@ -50,7 +50,7 @@ impl InMemoryIndex {
     pub fn new() -> InMemoryIndex {
         InMemoryIndex {
             word_count: 0,
-            map: HashMap::new()
+            map: HashMap::new(),
         }
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -91,8 +91,8 @@ impl InMemoryIndex {
     pub fn merge(&mut self, other: InMemoryIndex) {
         for (term, hits) in other.map {
             self.map.entry(term)
-                .or_insert_with(|| vec![])
-                .extend(hits)
+                .or_default()
+                .extend(hits);
         }
         self.word_count += other.word_count;
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -77,7 +77,7 @@ impl InMemoryIndex {
         }
 
         if document_id % 100 == 0 {
-            println!("indexed document {}, {} bytes, {} words", document_id, text.len(), index.word_count);
+            println!("indexed document {document_id}, {} bytes, {} words", text.len(), index.word_count);
         }
 
         index

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn run_single_threaded(documents: Vec<PathBuf>, output_dir: PathBuf) -> io::Resu
 fn start_file_reader_thread(
     documents: Vec<PathBuf>,
 ) -> (mpsc::Receiver<String>, thread::JoinHandle<io::Result<()>>) {
-    let (sender, receiver) = mpsc::channel();
+    let (sender, receiver) = mpsc::sync_channel(32);
 
     let handle = thread::spawn(move || {
         for filename in documents {
@@ -108,7 +108,7 @@ fn start_file_reader_thread(
 fn start_file_indexing_thread(
     texts: mpsc::Receiver<String>,
 ) -> (mpsc::Receiver<InMemoryIndex>, thread::JoinHandle<()>) {
-    let (sender, receiver) = mpsc::channel();
+    let (sender, receiver) = mpsc::sync_channel(32);
 
     let handle = thread::spawn(move || {
         for (doc_id, text) in texts.into_iter().enumerate() {
@@ -139,7 +139,7 @@ fn start_in_memory_merge_thread(
     file_indexes: mpsc::Receiver<InMemoryIndex>,
 ) -> (mpsc::Receiver<InMemoryIndex>, thread::JoinHandle<()>)
 {
-    let (sender, receiver) = mpsc::channel();
+    let (sender, receiver) = mpsc::sync_channel(32);
 
     let handle = thread::spawn(move || {
         let mut accumulated_index = InMemoryIndex::new();
@@ -173,7 +173,7 @@ fn start_index_writer_thread(
     output_dir: &Path,
 ) -> (mpsc::Receiver<PathBuf>, thread::JoinHandle<io::Result<()>>)
 {
-    let (sender, receiver) = mpsc::channel();
+    let (sender, receiver) = mpsc::sync_channel(32);
 
     let mut tmp_dir = TmpDir::new(output_dir);
     let handle = thread::spawn(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,9 +34,7 @@ use crate::tmp::TmpDir;
 
 /// Create an inverted index for the given list of `documents`,
 /// storing it in the specified `output_dir`.
-fn run_single_threaded(documents: Vec<PathBuf>, output_dir: PathBuf)
-    -> io::Result<()>
-{
+fn run_single_threaded(documents: Vec<PathBuf>, output_dir: PathBuf) -> io::Result<()> {
     // If all the documents fit comfortably in memory, we'll create the whole
     // index in memory.
     let mut accumulated_index = InMemoryIndex::new();
@@ -143,8 +141,9 @@ fn start_file_indexing_thread(texts: Receiver<String>)
 /// merging the input indexes; and a `JoinHandle` that can be used to wait for
 /// this thread to exit. This stage of the pipeline is infallible (it performs
 /// no I/O).
-fn start_in_memory_merge_thread(file_indexes: Receiver<InMemoryIndex>)
-    -> (Receiver<InMemoryIndex>, JoinHandle<()>)
+fn start_in_memory_merge_thread(
+    file_indexes: mpsc::Receiver<InMemoryIndex>,
+) -> (mpsc::Receiver<InMemoryIndex>, thread::JoinHandle<()>)
 {
     let (sender, receiver) = channel();
 
@@ -175,9 +174,10 @@ fn start_in_memory_merge_thread(file_indexes: Receiver<InMemoryIndex>)
 /// This returns a pair: a receiver that receives the filenames; and a
 /// `JoinHandle` that can be used to wait for this thread to exit and receive
 /// any I/O errors it encountered.
-fn start_index_writer_thread(big_indexes: Receiver<InMemoryIndex>,
-                             output_dir: &Path)
-    -> (Receiver<PathBuf>, JoinHandle<io::Result<()>>)
+fn start_index_writer_thread(
+    big_indexes: mpsc::Receiver<InMemoryIndex>,
+    output_dir: &Path,
+) -> (mpsc::Receiver<PathBuf>, thread::JoinHandle<io::Result<()>>)
 {
     let (sender, receiver) = channel();
 
@@ -197,8 +197,10 @@ fn start_index_writer_thread(big_indexes: Receiver<InMemoryIndex>,
 
 /// Given a sequence of filenames of index data files, merge all the files
 /// into a single index data file.
-fn merge_index_files(files: Receiver<PathBuf>, output_dir: &Path)
-    -> io::Result<()>
+fn merge_index_files(
+    files: mpsc::Receiver<PathBuf>,
+    output_dir: &Path,
+) -> io::Result<()>
 {
     let mut merge = FileMerge::new(output_dir);
     for file in files {
@@ -213,9 +215,10 @@ fn merge_index_files(files: Receiver<PathBuf>, output_dir: &Path)
 /// On success this does exactly the same thing as `run_single_threaded`, but
 /// faster since it uses multiple CPUs and keeps them busy while I/O is
 /// happening.
-fn run_pipeline(documents: Vec<PathBuf>, output_dir: PathBuf)
-    -> io::Result<()>
-{
+fn run_pipeline(
+    documents: Vec<PathBuf>,
+    output_dir: PathBuf,
+) -> io::Result<()> {
     // Launch all five stages of the pipeline.
     let (texts,   h1) = start_file_reader_thread(documents);
     let (pints,   h2) = start_file_indexing_thread(texts);
@@ -282,13 +285,20 @@ fn main() {
         let mut ap = ArgumentParser::new();
         ap.set_description("Make an inverted index for searching documents.");
         ap.refer(&mut single_threaded)
-            .add_option(&["-1", "--single-threaded"], StoreTrue,
-                        "Do all the work on a single thread.");
+            .add_option(
+                &["-1", "--single-threaded"],
+                StoreTrue,
+                "Do all the work on a single thread.",
+            );
         ap.refer(&mut filenames)
-            .add_argument("filenames", Collect,
-                          "Names of files/directories to index. \
-                           For directories, all .txt files immediately \
-                           under the directory are indexed.");
+            .add_argument(
+                "filenames",
+                Collect,
+                "\
+                    Names of files/directories to index. \
+                    For directories, all .txt files immediately \
+                    under the directory are indexed.",
+            );
         ap.parse_args_or_exit();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,17 @@
-/// `fingertips` creates an inverted index for a set of text files.
-///
-/// Most of the actual work is done by the modules `index`, `read`, `write`,
-/// and `merge`.  In this file, `main.rs`, we put the pieces together in two
-/// different ways.
-///
-/// *   `run_single_threaded` simply does everything in one thread, in
-///     the most straightforward possible way.
-///
-/// *   Then, we break the work into a five-stage pipeline so that we can run
-///     it on multiple CPUs. `run_pipeline` puts the five stages together.
-///
-/// The `main` function at the end handles command-line arguments. It calls one
-/// of the two functions above to do the work.
+//! `fingertips` creates an inverted index for a set of text files.
+//!
+//! Most of the actual work is done by the modules `index`, `read`, `write`,
+//! and `merge`.  In this file, `main.rs`, we put the pieces together in two
+//! different ways.
+//!
+//! *   `run_single_threaded` simply does everything in one thread, in
+//!     the most straightforward possible way.
+//!
+//! *   Then, we break the work into a five-stage pipeline so that we can run
+//!     it on multiple CPUs. `run_pipeline` puts the five stages together.
+//!
+//! The `main` function at the end handles command-line arguments. It calls one
+//! of the two functions above to do the work.
 
 mod index;
 mod read;

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,8 +296,7 @@ fn main() {
         ap.parse_args_or_exit();
     }
 
-    match run(filenames, single_threaded) {
-        Ok(()) => {}
-        Err(err) => println!("error: {}", err)
+    if let Err(err) = run(filenames, single_threaded) {
+        eprintln!("error: {err}");
     }
 }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -3,8 +3,8 @@ use std::io::{self, BufWriter};
 use std::mem;
 use std::path::{Path, PathBuf};
 
-use crate::tmp::TmpDir;
 use crate::read::IndexFileReader;
+use crate::tmp::TmpDir;
 use crate::write::IndexFileWriter;
 
 pub struct FileMerge {
@@ -63,22 +63,19 @@ impl FileMerge {
         }
         assert!(tmp.len() <= 1);
         match tmp.pop() {
-            Some(last_file) =>
-                fs::rename(last_file, self.output_dir.join(MERGED_FILENAME)),
-            None =>
-                Err(io::Error::new(io::ErrorKind::Other,
-                                   "no documents were parsed or none contained any words"))
+            Some(last_file) => fs::rename(last_file, self.output_dir.join(MERGED_FILENAME)),
+            None => Err(io::Error::other(
+                "no documents were parsed or none contained any words",
+            )),
         }
     }
 }
 
-fn merge_streams(files: Vec<PathBuf>, out: BufWriter<File>)
-    -> io::Result<()>
-{
-    let mut streams: Vec<IndexFileReader> =
-        files.into_iter()
-            .map(IndexFileReader::open_and_delete)
-            .collect::<io::Result<_>>()?;
+fn merge_streams(files: Vec<PathBuf>, out: BufWriter<File>) -> io::Result<()> {
+    let mut streams: Vec<IndexFileReader> = files
+        .into_iter()
+        .map(IndexFileReader::open_and_delete)
+        .collect::<io::Result<_>>()?;
 
     let mut output = IndexFileWriter::new(out)?;
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -10,7 +10,7 @@ use crate::write::IndexFileWriter;
 pub struct FileMerge {
     output_dir: PathBuf,
     tmp_dir: TmpDir,
-    stacks: Vec<Vec<PathBuf>>
+    stacks: Vec<Vec<PathBuf>>,
 }
 
 // How many files to merge at a time, at most.
@@ -23,7 +23,7 @@ impl FileMerge {
         FileMerge {
             output_dir: output_dir.to_owned(),
             tmp_dir: TmpDir::new(output_dir.to_owned()),
-            stacks: vec![]
+            stacks: vec![],
         }
     }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -16,13 +16,13 @@ pub struct FileMerge {
 // How many files to merge at a time, at most.
 const NSTREAMS: usize = 8;
 
-const MERGED_FILENAME: &'static str = "index.dat";
+const MERGED_FILENAME: &str = "index.dat";
 
 impl FileMerge {
     pub fn new(output_dir: &Path) -> FileMerge {
         FileMerge {
             output_dir: output_dir.to_owned(),
-            tmp_dir: TmpDir::new(output_dir.to_owned()),
+            tmp_dir: TmpDir::new(output_dir),
             stacks: vec![],
         }
     }
@@ -113,8 +113,8 @@ fn merge_streams(files: Vec<PathBuf>, out: BufWriter<File>)
                 }
             }
         }
-        output.write_contents_entry(term, df, point, nbytes as u64);
-        point += nbytes as u64;
+        output.write_contents_entry(term, df, point, nbytes);
+        point += nbytes;
     }
 
     assert!(streams.iter().all(|s| s.peek().is_none()));

--- a/src/read.rs
+++ b/src/read.rs
@@ -68,7 +68,10 @@ impl IndexFileReader {
 
         // Read the file header.
         let contents_offset = main_raw.read_u64::<LittleEndian>()?;
-        println!("opened {}, table of contents starts at {}", filename.display(), contents_offset);
+        println!(
+            "opened {}, table of contents starts at {contents_offset}",
+            filename.display()
+        );
 
         // Open again so we have two read heads;
         // move the contents read head to its starting position.

--- a/src/read.rs
+++ b/src/read.rs
@@ -30,7 +30,7 @@ pub struct IndexFileReader {
     /// The next entry in the table of contents, if any; or `None` if we've
     /// reached the end of the table. `IndexFileReader` always reads ahead one
     /// entry in the contents and stores it here.
-    next: Option<Entry>
+    next: Option<Entry>,
 }
 
 /// An entry in the table of contents of an index file.
@@ -51,7 +51,7 @@ pub struct Entry {
     pub offset: u64,
 
     /// Length of the index data for this term, in bytes.
-    pub nbytes: u64
+    pub nbytes: u64,
 }
 
 impl IndexFileReader {
@@ -84,9 +84,9 @@ impl IndexFileReader {
         fs::remove_file(filename)?;  // YOLO
 
         Ok(IndexFileReader {
-            main: main,
-            contents: contents,
-            next: first
+            main,
+            contents,
+            next: first,
         })
     }
 
@@ -118,10 +118,10 @@ impl IndexFileReader {
         };
 
         Ok(Some(Entry {
-            term: term,
-            df: df,
-            offset: offset,
-            nbytes: nbytes
+            term,
+            df,
+            offset,
+            nbytes,
         }))
     }
 
@@ -135,7 +135,7 @@ impl IndexFileReader {
     pub fn is_at(&self, term: &str) -> bool {
         match self.next {
             Some(ref e) => e.term == term,
-            None => false
+            None => false,
         }
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -50,6 +50,7 @@ pub struct Entry {
     pub df: u32,
 
     /// Offset of the index data for this term from the beginning of the file, in bytes.
+    #[expect(dead_code)]
     pub offset: u64,
 
     /// Length of the index data for this term, in bytes.

--- a/src/read.rs
+++ b/src/read.rs
@@ -5,7 +5,9 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io::{self, BufReader, SeekFrom};
 use std::path::Path;
+
 use byteorder::{LittleEndian, ReadBytesExt};
+
 use crate::write::IndexFileWriter;
 
 /// A `IndexFileReader` does a single linear pass over an index file from
@@ -84,7 +86,7 @@ impl IndexFileReader {
         // We always read ahead one entry, so load the first entry right away.
         let first = IndexFileReader::read_entry(&mut contents)?;
 
-        fs::remove_file(filename)?;  // YOLO
+        fs::remove_file(filename)?; // YOLO
 
         Ok(IndexFileReader {
             main,
@@ -101,12 +103,13 @@ impl IndexFileReader {
         // that's considered a success, with no entry read.
         let offset = match f.read_u64::<LittleEndian>() {
             Ok(value) => value,
-            Err(err) =>
+            Err(err) => {
                 if err.kind() == io::ErrorKind::UnexpectedEof {
-                    return Ok(None)
+                    return Ok(None);
                 } else {
-                    return Err(err)
+                    return Err(err);
                 }
+            }
         };
 
         let nbytes = f.read_u64::<LittleEndian>()?;
@@ -131,7 +134,9 @@ impl IndexFileReader {
     /// (Since we always read ahead one entry, this method can't fail.)
     ///
     /// Returns `None` if we've reached the end of the file.
-    pub fn peek(&self) -> Option<&Entry> { self.next.as_ref() }
+    pub fn peek(&self) -> Option<&Entry> {
+        self.next.as_ref()
+    }
 
     /// True if the next entry is for the given term.
     pub fn is_at(&self, term: &str) -> bool {

--- a/src/tmp.rs
+++ b/src/tmp.rs
@@ -17,7 +17,7 @@ impl TmpDir {
     }
 
     pub fn create(&mut self) -> io::Result<(PathBuf, BufWriter<File>)> {
-        let mut r#try = 1;
+        let mut attempt = 1;
         loop {
             let filename = self.dir.join(PathBuf::from(format!("tmp{:08x}.dat", self.n)));
             self.n += 1;
@@ -29,13 +29,13 @@ impl TmpDir {
                 Ok(f) =>
                     return Ok((filename, BufWriter::new(f))),
                 Err(exc) =>
-                    if r#try < 999 && exc.kind() == io::ErrorKind::AlreadyExists {
+                    if attempt < 999 && exc.kind() == io::ErrorKind::AlreadyExists {
                         // keep going
                     } else {
                         return Err(exc);
                     }
             }
-            r#try += 1;
+            attempt += 1;
         }
     }
 }

--- a/src/tmp.rs
+++ b/src/tmp.rs
@@ -5,14 +5,14 @@ use std::path::{Path, PathBuf};
 #[derive(Clone)]
 pub struct TmpDir {
     dir: PathBuf,
-    n: usize
+    n: usize,
 }
 
 impl TmpDir {
     pub fn new<P: AsRef<Path>>(dir: P) -> TmpDir {
         TmpDir {
             dir: dir.as_ref().to_owned(),
-            n: 1
+            n: 1,
         }
     }
 

--- a/src/tmp.rs
+++ b/src/tmp.rs
@@ -22,9 +22,9 @@ impl TmpDir {
             let filename = self.dir.join(PathBuf::from(format!("tmp{:08x}.dat", self.n)));
             self.n += 1;
             match fs::OpenOptions::new()
-                  .write(true)
-                  .create_new(true)
-                  .open(&filename)
+                .write(true)
+                .create_new(true)
+                .open(&filename)
             {
                 Ok(f) =>
                     return Ok((filename, BufWriter::new(f))),

--- a/src/write.rs
+++ b/src/write.rs
@@ -56,7 +56,7 @@ impl IndexFileWriter {
     pub fn finish(mut self) -> io::Result<()> {
         let contents_start = self.offset;
         self.writer.write_all(&self.contents_buf)?;
-        println!("{} bytes main, {} bytes total", contents_start, contents_start + self.contents_buf.len() as u64);
+        println!("{contents_start} bytes main, {} bytes total", contents_start + self.contents_buf.len() as u64);
         self.writer.seek(SeekFrom::Start(0))?;
         self.writer.write_u64::<LittleEndian>(contents_start)?;
         Ok(())
@@ -83,6 +83,6 @@ pub fn write_index_to_tmp_file(index: InMemoryIndex, tmp_dir: &mut TmpDir) -> io
     }
 
     writer.finish()?;
-    println!("wrote file {:?}", filename);
+    println!("wrote file {filename:?}");
     Ok(filename)
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -23,7 +23,7 @@ pub struct IndexFileWriter {
     writer: BufWriter<File>,
 
     /// The table of contents for this file.
-    contents_buf: Vec<u8>
+    contents_buf: Vec<u8>,
 }
 
 impl IndexFileWriter {
@@ -33,7 +33,7 @@ impl IndexFileWriter {
         Ok(IndexFileWriter {
             offset: HEADER_SIZE,
             writer: f,
-            contents_buf: vec![]
+            contents_buf: vec![],
         })
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -10,11 +10,7 @@ use byteorder::{LittleEndian, WriteBytesExt};
 ///
 /// The first 8 bytes of the index file contain the offset of the table of
 /// contents, in bytes. Then come the main entries, all stored back-to-back
-/// with no particular metadata.
-///
-
-/// An index file has two parts. The main part of the file is a sequence of
-/// entries, stored back-to-back; the
+/// with no particular metadata. Lastly there's the table of contents.
 pub struct IndexFileWriter {
     /// The number of bytes written so far.
     offset: u64,

--- a/src/write.rs
+++ b/src/write.rs
@@ -70,7 +70,7 @@ pub fn write_index_to_tmp_file(index: InMemoryIndex, tmp_dir: &mut TmpDir) -> io
     // The merge algorithm requires the entries within each file to be sorted by term.
     // Sort before writing anything.
     let mut index_as_vec: Vec<_> = index.map.into_iter().collect();
-    index_as_vec.sort_by(|&(ref a, _), &(ref b, _)| a.cmp(b));
+    index_as_vec.sort_by(|(a, _), (b, _)| a.cmp(b));
 
     for (term, hits) in index_as_vec {
         let df = hits.len() as u32;


### PR DESCRIPTION
Generally use new methods where they are handy; address new Clippy lints; run `rustfmt`; and so forth.